### PR TITLE
Add support for relative path deployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "build:pages": "tsc -b && vite build --mode pages",
+    "preview:pages": "vite preview --mode pages",
+    "deploy": "gh-pages -d dist",
     "lint": "eslint .",
     "format": "prettier --write 'src/**/*.{js,jsx,ts,tsx}'",
     "format:check": "prettier --check 'src/**/*.{js,jsx,ts,tsx}'",
-    "preview": "vite preview",
-    "knip": "knip",
-    "deploy": "gh-pages -d dist"
+    "knip": "knip"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.18.6",

--- a/src/sqlite/core.ts
+++ b/src/sqlite/core.ts
@@ -32,7 +32,7 @@ export default class Sqlite {
   }
 
   // Initialize SQL.js
-  
+
   private static async initSQLjs(): Promise<SqlJsStatic> {
     if (Sqlite.sqlJsStatic) return Sqlite.sqlJsStatic;
     return await initSqlJs({

--- a/src/sqlite/core.ts
+++ b/src/sqlite/core.ts
@@ -32,10 +32,11 @@ export default class Sqlite {
   }
 
   // Initialize SQL.js
+  
   private static async initSQLjs(): Promise<SqlJsStatic> {
     if (Sqlite.sqlJsStatic) return Sqlite.sqlJsStatic;
     return await initSqlJs({
-      locateFile: (file) => `${import.meta.env.BASE_URL}../wasm/${file}`
+      locateFile: (file) => `${import.meta.env.BASE_URL}wasm/${file}`
     });
   }
 

--- a/src/sqlite/core.ts
+++ b/src/sqlite/core.ts
@@ -35,7 +35,7 @@ export default class Sqlite {
   private static async initSQLjs(): Promise<SqlJsStatic> {
     if (Sqlite.sqlJsStatic) return Sqlite.sqlJsStatic;
     return await initSqlJs({
-      locateFile: (file) => `${import.meta.env.BASE_URL}wasm/${file}`
+      locateFile: (file) => `${import.meta.env.BASE_URL}../wasm/${file}`
     });
   }
 
@@ -156,7 +156,7 @@ export default class Sqlite {
   // Used for pagination
   private getMaxSizeOfTable(tableName: string, filters?: Filters) {
     const [results] = this.exec(`
-      SELECT COUNT(*) FROM "${tableName}" 
+      SELECT COUNT(*) FROM "${tableName}"
       ${buildWhereClause(filters)}
     `);
 
@@ -175,9 +175,9 @@ export default class Sqlite {
     sorters?: Sorters
   ) {
     const [results] = this.exec(`
-      SELECT ${this.tablesSchema[table].primaryKey}, * FROM "${table}" 
-      ${buildWhereClause(filters)} 
-      ${buildOrderByClause(sorters)} 
+      SELECT ${this.tablesSchema[table].primaryKey}, * FROM "${table}"
+      ${buildWhereClause(filters)}
+      ${buildOrderByClause(sorters)}
       LIMIT ${limit} OFFSET ${offset}
     `);
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,8 +7,12 @@ import compression from "vite-plugin-compression";
 import viteImagemin from "vite-plugin-imagemin";
 import babelReactCompiler from "babel-plugin-react-compiler";
 
-export default defineConfig({
-  base: "./",
+export default defineConfig(({ mode }) => {
+  const isPages = mode === 'pages';
+  console.log('Mode:', mode);
+  
+  return {
+  base: isPages ? '/sqlite-online/' : '/',
   plugins: [
     react({
       babel: {
@@ -71,4 +75,5 @@ export default defineConfig({
       strict: false
     }
   }
-});
+}
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ import viteImagemin from "vite-plugin-imagemin";
 import babelReactCompiler from "babel-plugin-react-compiler";
 
 export default defineConfig({
-  base: "/sqlite-online/",
+  base: "./",
   plugins: [
     react({
       babel: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,68 +12,68 @@ export default defineConfig(({ mode }) => {
   console.log('Mode:', mode);
   
   return {
-  base: isPages ? '/sqlite-online/' : '/',
-  plugins: [
-    react({
-      babel: {
-        plugins: [babelReactCompiler]
-      }
-    }),
-    tailwindcss(),
-    compression(),
-    viteImagemin({
-      gifsicle: {
-        optimizationLevel: 7,
-        interlaced: false
-      },
-      optipng: {
-        optimizationLevel: 7
-      },
-      mozjpeg: {
-        quality: 20
-      },
-      pngquant: {
-        quality: [0.8, 0.9],
-        speed: 4
-      },
-      svgo: {
-        plugins: [
-          {
-            name: "removeViewBox"
-          },
-          {
-            name: "removeEmptyAttrs",
-            active: false
-          }
-        ]
-      }
-    })
-  ],
-  build: {
-    rollupOptions: {
-      output: {
-        manualChunks(id) {
-          if (id.includes("node_modules")) {
-            return id
-              .toString()
-              .split("node_modules/")[1]
-              .split("/")[0]
-              .toString();
+    base: isPages ? '/sqlite-online/' : '/',
+    plugins: [
+      react({
+        babel: {
+          plugins: [babelReactCompiler]
+        }
+      }),
+      tailwindcss(),
+      compression(),
+      viteImagemin({
+        gifsicle: {
+          optimizationLevel: 7,
+          interlaced: false
+        },
+        optipng: {
+          optimizationLevel: 7
+        },
+        mozjpeg: {
+          quality: 20
+        },
+        pngquant: {
+          quality: [0.8, 0.9],
+          speed: 4
+        },
+        svgo: {
+          plugins: [
+            {
+              name: "removeViewBox"
+            },
+            {
+              name: "removeEmptyAttrs",
+              active: false
+            }
+          ]
+        }
+      })
+    ],
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes("node_modules")) {
+              return id
+                .toString()
+                .split("node_modules/")[1]
+                .split("/")[0]
+                .toString();
+            }
           }
         }
       }
-    }
-  },
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src")
-    }
-  },
-  server: {
-    fs: {
-      allow: [path.resolve(__dirname), path.resolve(__dirname, "..")],
-      strict: false
+    },
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src")
+      }
+    },
+    server: {
+      fs: {
+        allow: [path.resolve(__dirname), path.resolve(__dirname, "..")],
+        strict: false
+      }
     }
   }
-}
 })


### PR DESCRIPTION
First off, thank you for making this awesome tool!

This change allows you to deploy this tool at any relative path instead of relying on the URL to be `https://example.com/sqlite-online/...` and now you can deploy this tool to `https://example.com/static/tools/anywhere/...` or even `https://example.com/`

Please feel free to adjust as needed, but this unblocks my use-case for this tool, so I wanted to contribute back.